### PR TITLE
🐛 fix: Correct import path for userStore in ATMPage.vue

### DIFF
--- a/src/components/pages/ATMPage.vue
+++ b/src/components/pages/ATMPage.vue
@@ -26,7 +26,7 @@
 <script>
 import { login } from "@/queries/users";
 import { useToast } from "vue-toastification";
-import { useUserStore } from "@/stores/UserStore";
+import { useUserStore } from "@/stores/userStore";
 
 const toast = useToast();
 export default {


### PR DESCRIPTION
Fixes incorrect import path for userStore

Corrects the import statement for the userStore module in ATMPage.vue to resolve potential module resolution issues or errors caused by case sensitivity in the file name.